### PR TITLE
Add basic CORS setup

### DIFF
--- a/webApiSimulation/webApiSimulation/Program.cs
+++ b/webApiSimulation/webApiSimulation/Program.cs
@@ -6,11 +6,19 @@ builder.WebHost.UseUrls("http://0.0.0.0:5500");
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(); // volitelné
+builder.Services.AddCors();
 
 var app = builder.Build();
 
 // ❌ Můžeš zakomentovat nebo smazat, protože https nepoužíváš
 // app.UseHttpsRedirection();
+
+app.UseCors(policy =>
+{
+    policy.AllowAnyOrigin()
+          .AllowAnyHeader()
+          .AllowAnyMethod();
+});
 
 app.UseAuthorization();
 


### PR DESCRIPTION
## Summary
- allow webApiSimulation cross-origin requests on all headers/methods/origins

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870b3accaf0832bbc5cbff908bef7a0