### PR TITLE
Revert ApiSender to localhost

### DIFF
--- a/PlcDataCollector/PlcDataCollector/Program.cs
+++ b/PlcDataCollector/PlcDataCollector/Program.cs
@@ -13,9 +13,8 @@ catch (Exception ex)
     return;
 }
 
-// 🔧 Zařízení má IP 192.168.0.11 a PLC je na 192.168.0.10
-// Web API na zařízení tedy oslovujeme přes jeho IP adresu
-var apiSender = new ApiSender("http://192.168.0.11:5500/api/machines");
+// ⚠️ Komunikace přes localhost, protože běží na stejném zařízení
+var apiSender = new ApiSender("http://localhost:5500/api/machines");
 
 while (true)
 {


### PR DESCRIPTION
## Summary
- revert machine API endpoint to localhost

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870be80e914832bb3e1efe3732586bb